### PR TITLE
fixed inference error due to incorrect S3 prefix

### DIFF
--- a/Segmentation/MONAI_BYOS_spleen_segmentation_3D_Demo.ipynb
+++ b/Segmentation/MONAI_BYOS_spleen_segmentation_3D_Demo.ipynb
@@ -446,7 +446,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prefix_key = f\"{prefix}/demo_test\"\n",
+    "prefix_key = f\"{prefix}/test\"\n",
     "file = test_demo_files[0][\"image\"].split(\"/\")[-1]\n",
     "print(file)"
    ]
@@ -770,9 +770,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -784,7 +784,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
The Segmentation notebook failed on inference test since the S3 prefix is incorrect. It tries to access /demo_test, while the data is actually stored in S3 with prefix /test.

*Description of changes:*
Changed the prefix from /demo_test to /test
Test has been performed by running the notebook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
